### PR TITLE
Feat: 공통 컴포넌트 중 태그, 디데이 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,15 +14,15 @@
       },
       "devDependencies": {
         "@types/node": "^20",
-        "@types/react": "^18",
-        "@types/react-dom": "^18",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.15",
         "eslint-config-prettier": "^9.1.0",
         "postcss": "^8",
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.1",
-        "typescript": "^5"
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -514,18 +514,16 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.11.tgz",
       "integrity": "sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.0",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
-      "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
@@ -5048,7 +5046,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   },
   "devDependencies": {
     "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
+    "@types/react": "^18.3.11",
+    "@types/react-dom": "^18.3.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.15",
     "eslint-config-prettier": "^9.1.0",
     "postcss": "^8",
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5"
+    "typescript": "^5.6.3"
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,9 +11,9 @@ export default function Home() {
         <BannerLink url="https://google.com" />
       </div>
       <div className='flex gap-2 mb-4'>
-        <Tag type="hot" />
-        <Tag type="best" />
-        <Tag type="new" />
+        <Tag type="hot" label="HOT"/>
+        <Tag type="best" label="BEST"/>
+        <Tag type="new" label="NEW"/>
       </div>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import BannerLink from '@/components/common/BannerLink';
+import Tag from '@/components/common/Tag';
 
 export default function Home() {
   return (
@@ -8,6 +9,11 @@ export default function Home() {
         <BannerLink url="https://google.com" />
         <BannerLink url="https://google.com" />
         <BannerLink url="https://google.com" />
+      </div>
+      <div className='flex gap-2 mb-4'>
+        <Tag type="hot" />
+        <Tag type="best" />
+        <Tag type="new" />
       </div>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import BannerLink from '@/components/common/BannerLink';
+import Dday from '@/components/common/Dday';
 import Tag from '@/components/common/Tag';
 
 export default function Home() {
@@ -11,9 +12,16 @@ export default function Home() {
         <BannerLink url="https://google.com" />
       </div>
       <div className='flex gap-2 mb-4'>
-        <Tag type="hot" label="HOT"/>
-        <Tag type="best" label="BEST"/>
-        <Tag type="new" label="NEW"/>
+        <Tag type="hot" label="HOT" />
+        <Tag type="best" label="BEST" />
+        <Tag type="new" label="NEW" />
+      </div>
+      <div>
+        <Dday type="active" day="30" color="red" />
+        <Dday type="active" day="00" color="green" />
+        <Dday type="active" day="30" color="yellow" />
+        <Dday type="upcoming" day="30" />
+        <Dday type="completed" day="30" />
       </div>
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import BannerLink from '@/components/common/BannerLink';
 import Dday from '@/components/common/Dday';
 import Tag from '@/components/common/Tag';
 
@@ -6,11 +5,6 @@ export default function Home() {
   return (
     <>
       <h1>main component</h1>
-      <div className="flex flex-col gap-4 justify-center h-screen items-center">
-        <BannerLink url="https://google.com" />
-        <BannerLink url="https://google.com" />
-        <BannerLink url="https://google.com" />
-      </div>
       <div className="flex gap-2 mb-4">
         <Tag type="hot" label="HOT" />
         <Tag type="best" label="BEST" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,17 +11,17 @@ export default function Home() {
         <BannerLink url="https://google.com" />
         <BannerLink url="https://google.com" />
       </div>
-      <div className='flex gap-2 mb-4'>
+      <div className="flex gap-2 mb-4">
         <Tag type="hot" label="HOT" />
         <Tag type="best" label="BEST" />
         <Tag type="new" label="NEW" />
       </div>
-      <div>
+      <div className="flex gap-2 mb-4">
         <Dday type="active" day="30" color="red" />
         <Dday type="active" day="00" color="green" />
-        <Dday type="active" day="30" color="yellow" />
-        <Dday type="upcoming" day="30" />
-        <Dday type="completed" day="30" />
+        <Dday type="active" day="00" color="yellow" />
+        <Dday type="upcoming" />
+        <Dday type="completed" />
       </div>
     </>
   );

--- a/src/components/common/Dday.tsx
+++ b/src/components/common/Dday.tsx
@@ -1,30 +1,30 @@
 interface DdayProps {
   type: 'active' | 'completed' | 'upcoming';
-  day: string;
+  day?: string;
   color?: 'red' | 'yellow' | 'green';
 }
 
 const baseTagStyle = "h-[33px] px-2 py-[3px] rounded-[999px] justify-center items-center gap-1.5 inline-flex";
-const baseTextStyle = "text-lg font-medium font-['Pretendard'] leading-[27px]";
+const baseTextStyle = "text-lg font-medium font-pretendard leading-[27px]";
 
 const tagStyles = {
   active: {
-    red: `${baseTagStyle} bg-[#f9dada]`,
-    yellow: `${baseTagStyle} bg-[#fcefda]`,
-    green: `${baseTagStyle} bg-[#dbe3dc]`,
+    red: `${baseTagStyle} bg-dDayRed`,
+    yellow: `${baseTagStyle} bg-dDayYellow`,
+    green: `${baseTagStyle} bg-dDayGreen`,
   },
-  completed: `${baseTagStyle} bg-[#D3D3D3]`,
-  upcoming: `${baseTagStyle} bg-[#dbe3dc]`
+  completed: `${baseTagStyle} bg-dDayGray`,
+  upcoming: `${baseTagStyle} bg-dDayGreen`
 };
 
 const textStyles = {
   active: {
-    red: `${baseTextStyle} text-[#e24444]`,
-    yellow: `${baseTextStyle} text-[#f2ad48]`,
-    green: `${baseTextStyle} text-[#4a734e]`,
+    red: `${baseTextStyle} text-dDayTextRed`,
+    yellow: `${baseTextStyle} text-dDayTextYellow`,
+    green: `${baseTextStyle} text-dDayTextGreen`,
   },
-  completed: `${baseTextStyle} text-[#7A7A7A]`,
-  upcoming: `${baseTextStyle} text-[#4a734e]`
+  completed: `${baseTextStyle} text-dDayTextGray`,
+  upcoming: `${baseTextStyle} text-dDayTextGreen`
 };
 
 export default function Dday({ type, day, color }: DdayProps) {

--- a/src/components/common/Dday.tsx
+++ b/src/components/common/Dday.tsx
@@ -4,8 +4,8 @@ interface DdayProps {
   color?: 'red' | 'yellow' | 'green';
 }
 
-const baseTagStyle = "h-[33px] px-2 py-[3px] rounded-[999px] justify-center items-center gap-1.5 inline-flex";
-const baseTextStyle = "text-lg font-medium font-pretendard leading-[27px]";
+const baseTagStyle = "h-[33px] px-2 py-[3px] rounded-[999px] justify-center items-center gap-1.5 inline-flex flex-wrap min-w-[85px] max-w-[120px] text-sm sm:text-sm md:text-base";
+const baseTextStyle = "font-medium font-pretendard leading-[27px] text-center";
 
 const tagStyles = {
   active: {
@@ -31,7 +31,11 @@ export default function Dday({ type, day, color }: DdayProps) {
   if (type === "active" && color) {
     return (
       <div className={tagStyles.active[color]}>
-        <img src={`/assets/common/Plain_${color}_t.svg`} alt="Icon" className="w-6 h-6" />
+        <img 
+          src={`/assets/common/Plain_${color}_t.svg`} 
+          alt="Icon" 
+          className={`min-w-[24px] min-h-[24px]`}
+        />
         <span className={textStyles.active[color]}>
           D-{day}
         </span>
@@ -40,7 +44,11 @@ export default function Dday({ type, day, color }: DdayProps) {
   } else if (type === "completed") {
     return (
       <div className={tagStyles['completed']}>
-        <img src="/assets/common/Plain_gray_t.svg" alt="Icon" className="w-6 h-6" />
+        <img 
+          src="/assets/common/Plain_gray_t.svg" 
+          alt="Icon" 
+          className={`min-w-[24px] min-h-[24px]`}
+        />
         <span className={textStyles['completed']}>
           마감
         </span>
@@ -49,7 +57,11 @@ export default function Dday({ type, day, color }: DdayProps) {
   } else {  // upcoming
     return (
       <div className={tagStyles['upcoming']}>
-        <img src="/assets/common/Plain_green_t.svg" alt="Icon" className="w-6 h-6" />
+        <img 
+          src="/assets/common/Plain_green_t.svg" 
+          alt="Icon" 
+          className={`min-w-[24px] min-h-[24px]`}
+        />
         <span className={textStyles['upcoming']}>
           예정
         </span>

--- a/src/components/common/Dday.tsx
+++ b/src/components/common/Dday.tsx
@@ -1,0 +1,59 @@
+interface DdayProps {
+  type: 'active' | 'completed' | 'upcoming';
+  day: string;
+  color?: 'red' | 'yellow' | 'green';
+}
+
+const baseTagStyle = "h-[33px] px-2 py-[3px] rounded-[999px] justify-center items-center gap-1.5 inline-flex";
+const baseTextStyle = "text-lg font-medium font-['Pretendard'] leading-[27px]";
+
+const tagStyles = {
+  active: {
+    red: `${baseTagStyle} bg-[#f9dada]`,
+    yellow: `${baseTagStyle} bg-[#fcefda]`,
+    green: `${baseTagStyle} bg-[#dbe3dc]`,
+  },
+  completed: `${baseTagStyle} bg-[#D3D3D3]`,
+  upcoming: `${baseTagStyle} bg-[#dbe3dc]`
+};
+
+const textStyles = {
+  active: {
+    red: `${baseTextStyle} text-[#e24444]`,
+    yellow: `${baseTextStyle} text-[#f2ad48]`,
+    green: `${baseTextStyle} text-[#4a734e]`,
+  },
+  completed: `${baseTextStyle} text-[#7A7A7A]`,
+  upcoming: `${baseTextStyle} text-[#4a734e]`
+};
+
+export default function Dday({ type, day, color }: DdayProps) {
+  if (type === "active" && color) {
+    return (
+      <div className={tagStyles.active[color]}>
+        <img src={`/assets/common/Plain_${color}_t.svg`} alt="Icon" className="w-6 h-6" />
+        <span className={textStyles.active[color]}>
+          D-{day}
+        </span>
+      </div>
+    );
+  } else if (type === "completed") {
+    return (
+      <div className={tagStyles['completed']}>
+        <img src="/assets/common/Plain_gray_t.svg" alt="Icon" className="w-6 h-6" />
+        <span className={textStyles['completed']}>
+          마감
+        </span>
+      </div>
+    );
+  } else {  // upcoming
+    return (
+      <div className={tagStyles['upcoming']}>
+        <img src="/assets/common/Plain_green_t.svg" alt="Icon" className="w-6 h-6" />
+        <span className={textStyles['upcoming']}>
+          예정
+        </span>
+      </div>
+    );
+  }
+}

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -4,7 +4,7 @@ interface TagProps {
 }
 
 const baseTagStyle = "h-[33px] px-2 py-[3px] rounded-[999px] justify-center items-center gap-1.5 inline-flex";
-const baseTextStyle = "text-lg font-medium font-pretendard leading-[27px]";
+const baseTextStyle = "text-base font-medium font-pretendard leading-[27px]";
 
 const tagStyles = {
   hot: `${baseTagStyle} bg-dDayRed`,

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,49 +1,26 @@
 interface TagProps {
   type: 'hot' | 'best' | 'new';
+  label: string;
 }
 
-export default function Tag({ type }: TagProps) {
-  if (type === 'hot') {
-    return (
-      <div className="
-        h-[33px] px-2 py-[3px] bg-[#f9dada] rounded-[999px] 
-        justify-center items-center gap-1.5 inline-flex
-      ">
-        <div className="
-          text-[#e24444] text-lg font-medium 
-          font-['Pretendard'] leading-[27px]
-        ">
-          HOT
-        </div>
+const tagStyles = {
+  hot: "h-[33px] px-2 py-[3px] bg-[#f9dada] rounded-[999px] justify-center items-center gap-1.5 inline-flex",
+  best: "h-[33px] px-2 py-[3px] bg-[#dbe3dc] rounded-[999px] justify-center items-center gap-1.5 inline-flex",
+  new: "h-[33px] px-2 py-[3px] bg-[#fcefda] rounded-[999px] justify-center items-center gap-1.5 inline-flex"
+};
+
+const textStyles = {
+  hot: "text-[#e24444] text-lg font-medium font-['Pretendard'] leading-[27px]",
+  best: "text-[#4a734e] text-lg font-medium font-['Pretendard'] leading-[27px]",
+  new: "text-[#f2ad48] text-lg font-medium font-['Pretendard'] leading-[27px]"
+};
+
+export default function Tag({ type, label }: TagProps) {
+  return (
+    <div className={tagStyles[type]}>
+      <div className={textStyles[type]}>
+        {label}
       </div>
-    );
-  } else if (type === 'best') {
-    return (
-      <div className="
-        h-[33px] px-2 py-[3px] bg-[#dbe3dc] rounded-[999px] 
-        justify-center items-center gap-1.5 inline-flex
-      ">
-        <div className="
-          text-[#4a734e] text-lg font-medium 
-          font-['Pretendard'] leading-[27px]
-        ">
-          BEST
-        </div>
-      </div>
-    );
-  } else {
-    return (
-      <div className="
-        h-[33px] px-2 py-[3px] bg-[#fcefda] rounded-[999px] 
-        justify-center items-center gap-1.5 inline-flex
-      ">
-        <div className="
-          text-[#f2ad48] text-lg font-medium 
-          font-['Pretendard'] leading-[27px]
-        ">
-          NEW
-        </div>
-      </div>
-    );
-  }
+    </div>
+  );
 }

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -3,16 +3,19 @@ interface TagProps {
   label: string;
 }
 
+const baseTagStyle = "h-[33px] px-2 py-[3px] rounded-[999px] justify-center items-center gap-1.5 inline-flex";
+const baseTextStyle = "text-lg font-medium font-['Pretendard'] leading-[27px]";
+
 const tagStyles = {
-  hot: "h-[33px] px-2 py-[3px] bg-[#f9dada] rounded-[999px] justify-center items-center gap-1.5 inline-flex",
-  best: "h-[33px] px-2 py-[3px] bg-[#dbe3dc] rounded-[999px] justify-center items-center gap-1.5 inline-flex",
-  new: "h-[33px] px-2 py-[3px] bg-[#fcefda] rounded-[999px] justify-center items-center gap-1.5 inline-flex"
+  hot: `${baseTagStyle} bg-[#f9dada]`,
+  best: `${baseTagStyle} bg-[#dbe3dc]`,
+  new: `${baseTagStyle} bg-[#fcefda]`
 };
 
 const textStyles = {
-  hot: "text-[#e24444] text-lg font-medium font-['Pretendard'] leading-[27px]",
-  best: "text-[#4a734e] text-lg font-medium font-['Pretendard'] leading-[27px]",
-  new: "text-[#f2ad48] text-lg font-medium font-['Pretendard'] leading-[27px]"
+  hot: `${baseTextStyle} text-[#e24444]`,
+  best: `${baseTextStyle} text-[#4a734e]`,
+  new: `${baseTextStyle} text-[#f2ad48]`
 };
 
 export default function Tag({ type, label }: TagProps) {

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -4,18 +4,18 @@ interface TagProps {
 }
 
 const baseTagStyle = "h-[33px] px-2 py-[3px] rounded-[999px] justify-center items-center gap-1.5 inline-flex";
-const baseTextStyle = "text-lg font-medium font-['Pretendard'] leading-[27px]";
+const baseTextStyle = "text-lg font-medium font-pretendard leading-[27px]";
 
 const tagStyles = {
-  hot: `${baseTagStyle} bg-[#f9dada]`,
-  best: `${baseTagStyle} bg-[#dbe3dc]`,
-  new: `${baseTagStyle} bg-[#fcefda]`
+  hot: `${baseTagStyle} bg-dDayRed`,
+  new: `${baseTagStyle} bg-dDayYellow`,
+  best: `${baseTagStyle} bg-dDayGreen`
 };
 
 const textStyles = {
-  hot: `${baseTextStyle} text-[#e24444]`,
-  best: `${baseTextStyle} text-[#4a734e]`,
-  new: `${baseTextStyle} text-[#f2ad48]`
+  hot: `${baseTextStyle} text-dDayTextRed`,
+  new: `${baseTextStyle} text-dDayTextYellow`,
+  best: `${baseTextStyle} text-dDayTextGreen`
 };
 
 export default function Tag({ type, label }: TagProps) {

--- a/src/components/common/Tag.tsx
+++ b/src/components/common/Tag.tsx
@@ -1,0 +1,49 @@
+interface TagProps {
+  type: 'hot' | 'best' | 'new';
+}
+
+export default function Tag({ type }: TagProps) {
+  if (type === 'hot') {
+    return (
+      <div className="
+        h-[33px] px-2 py-[3px] bg-[#f9dada] rounded-[999px] 
+        justify-center items-center gap-1.5 inline-flex
+      ">
+        <div className="
+          text-[#e24444] text-lg font-medium 
+          font-['Pretendard'] leading-[27px]
+        ">
+          HOT
+        </div>
+      </div>
+    );
+  } else if (type === 'best') {
+    return (
+      <div className="
+        h-[33px] px-2 py-[3px] bg-[#dbe3dc] rounded-[999px] 
+        justify-center items-center gap-1.5 inline-flex
+      ">
+        <div className="
+          text-[#4a734e] text-lg font-medium 
+          font-['Pretendard'] leading-[27px]
+        ">
+          BEST
+        </div>
+      </div>
+    );
+  } else {
+    return (
+      <div className="
+        h-[33px] px-2 py-[3px] bg-[#fcefda] rounded-[999px] 
+        justify-center items-center gap-1.5 inline-flex
+      ">
+        <div className="
+          text-[#f2ad48] text-lg font-medium 
+          font-['Pretendard'] leading-[27px]
+        ">
+          NEW
+        </div>
+      </div>
+    );
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -23,10 +23,7 @@ const config: Config = {
         dDayTextGreen: '#4A734E',
         dDayTextGray: '#7A7A7A',
         searchBorder: '#E24444',
-      },
-      fontFamily: {
-        pretendard: ['Pretendard', 'sans-serif'],
-      },
+      }
     },
   },
   plugins: [],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,9 @@ const config: Config = {
         dDayTextGray: '#7A7A7A',
         searchBorder: '#E24444',
       },
+      fontFamily: {
+        pretendard: ['Pretendard', 'sans-serif'],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 변경 사항 설명
토마토들 서비스에서 사용될 태그 컴포넌트, 디데이 컴포넌트 구현

<img width="448" alt="Screenshot 2024-10-13 at 22 35 34" src="https://github.com/user-attachments/assets/77bffc3f-bfb6-441c-8ede-46b41d90c34a">

## 관련 이슈
#9 

## 변경 유형
- [X] 새로운 기능: 태그, 디데이 컴포넌트를 디자인에 알맞게 구현
- [X] 리팩토링 (기능 변경 없음)
    - tailwind CSS를 적용할 때 중복되는 부분이 많아 이를 상수로 빼서 적용.
    - 📁 _tailwind.config.ts_ 에서 미리 설정해놓았던 컬러 상수 적용.
    - 폰트가 적용되는 줄 알았는데 아니었던 ... 적용 완 🫡
    - D-day 컴포넌트 구현 시, 타입마다 필요로 하는 props의 개수를 다르게 적용 etc.


## 체크리스트
- [X] 내 코드가 프로젝트의 코드 컨벤션을 따르고 있습니다.
- [X] 필요한 경우, 주석을 추가했습니다.

## 추가 정보
제가 구현한 이 두 가지 컴포넌트는 반응형으로 할 필요가 없을 것 같아 적용하지 않고 마무리한 상태입니다. 적용해야 할지 같이 고민해주시면 감사하겠습니다 ( ◡̉̈ ) 

(수정 - 디테일이 살짝 달라졌어요!)

<img width="458" alt="Screenshot 2024-10-14 at 00 21 46" src="https://github.com/user-attachments/assets/80dd828a-11e6-456d-b64e-ac2ce8b7385b">
